### PR TITLE
Fix props types of array props in ComposableContext type

### DIFF
--- a/src/types-handling.ts
+++ b/src/types-handling.ts
@@ -35,7 +35,7 @@ export type ComposableContext<Props, Data, Computed, Methods, Args> = (Props ext
      * ["title"] -> { title: ArgType | any }
      */
     {
-      readonly [P in Props[number]]: Args extends { [K in keyof Props[number]]: infer ArgType } ? ArgType : any
+      readonly [P in Props]: Args extends { [K in keyof Props]: infer ArgType } ? ArgType : any
     }
   : /**
      * { title: Number } -> { title: Number | undefined }


### PR DESCRIPTION
## Description

This pull request addresses an issue with the props types of array props in the `ComposableContext` type. It fixes the typing inconsistency to ensure that array props are handled correctly.

## Changes Made

- Modified the `ComposableContext` type in `src/types-handling.ts` to properly handle props with array types.